### PR TITLE
GitHub comments

### DIFF
--- a/chute.xcodeproj/project.pbxproj
+++ b/chute.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		DC0E13A21F5CE89300525E5B /* InfoPlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E13A11F5CE89300525E5B /* InfoPlist.swift */; };
 		DC0E13A41F5CEC7500525E5B /* TestSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E13A31F5CEC7500525E5B /* TestSummary.swift */; };
 		DC0E13A61F5DEA3500525E5B /* ChuteDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E13A51F5DEA3500525E5B /* ChuteDetail.swift */; };
+		DC3062961FA9EFD6002332F6 /* GithubNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3062951FA9EFD6002332F6 /* GithubNotifier.swift */; };
 		DC42CF2E1F926E3A00279110 /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC42CF2D1F926E3A00279110 /* URL+Extensions.swift */; };
 		DC42CF301F92A25D00279110 /* ChuteTestResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC42CF2F1F92A25D00279110 /* ChuteTestResult.swift */; };
 		DC42CF321F92A27B00279110 /* ChuteTestAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC42CF311F92A27B00279110 /* ChuteTestAttachment.swift */; };
@@ -48,6 +49,7 @@
 		DC8019D01F9ABB600013CD20 /* ChuteOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8019CF1F9ABB600013CD20 /* ChuteOutput.swift */; };
 		DC86EF7E1FA678D500F9DB5A /* ChuteCodeCoverageDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC86EF7D1FA678D500F9DB5A /* ChuteCodeCoverageDifference.swift */; };
 		DC86EF801FA679C600F9DB5A /* ChuteCodeCoverageSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC86EF7F1FA679C600F9DB5A /* ChuteCodeCoverageSummary.swift */; };
+		DC8BA6431FAA04BF00031B89 /* GithubDetailDifferenceComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8BA6421FAA04BF00031B89 /* GithubDetailDifferenceComment.swift */; };
 		DCACC6BE1FA6483600697691 /* ChuteTestResultDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCACC6BD1FA6483600697691 /* ChuteTestResultDifference.swift */; };
 		DCACC6C01FA64CB400697691 /* ChuteHTMLDifferenceTestDetailReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCACC6BF1FA64CB400697691 /* ChuteHTMLDifferenceTestDetailReport.swift */; };
 		DCBB92A91F9EC19E00EE1C68 /* ChuteDetailDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBB92A81F9EC19E00EE1C68 /* ChuteDetailDifference.swift */; };
@@ -82,6 +84,7 @@
 		DC0E13A51F5DEA3500525E5B /* ChuteDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChuteDetail.swift; sourceTree = "<group>"; };
 		DC26B59E1F997F63002541C6 /* chuteTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = chuteTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC26B5A21F997F63002541C6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DC3062951FA9EFD6002332F6 /* GithubNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubNotifier.swift; sourceTree = "<group>"; };
 		DC42CF2D1F926E3A00279110 /* URL+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Extensions.swift"; sourceTree = "<group>"; };
 		DC42CF2F1F92A25D00279110 /* ChuteTestResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChuteTestResult.swift; sourceTree = "<group>"; };
 		DC42CF311F92A27B00279110 /* ChuteTestAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChuteTestAttachment.swift; sourceTree = "<group>"; };
@@ -100,6 +103,7 @@
 		DC8019CF1F9ABB600013CD20 /* ChuteOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChuteOutput.swift; sourceTree = "<group>"; };
 		DC86EF7D1FA678D500F9DB5A /* ChuteCodeCoverageDifference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChuteCodeCoverageDifference.swift; sourceTree = "<group>"; };
 		DC86EF7F1FA679C600F9DB5A /* ChuteCodeCoverageSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChuteCodeCoverageSummary.swift; sourceTree = "<group>"; };
+		DC8BA6421FAA04BF00031B89 /* GithubDetailDifferenceComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubDetailDifferenceComment.swift; sourceTree = "<group>"; };
 		DCACC6BD1FA6483600697691 /* ChuteTestResultDifference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChuteTestResultDifference.swift; sourceTree = "<group>"; };
 		DCACC6BF1FA64CB400697691 /* ChuteHTMLDifferenceTestDetailReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChuteHTMLDifferenceTestDetailReport.swift; sourceTree = "<group>"; };
 		DCBB92A81F9EC19E00EE1C68 /* ChuteDetailDifference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChuteDetailDifference.swift; sourceTree = "<group>"; };
@@ -151,13 +155,14 @@
 		DC0E13971F5CE25E00525E5B /* chute */ = {
 			isa = PBXGroup;
 			children = (
-				DC46C4881F9AA337008B17CD /* Common */,
 				DC5F53E31F94D4B900844C98 /* ChuteDetail */,
 				DCBB92A71F9EC17D00EE1C68 /* ChuteDetailDifference */,
+				DC46C4881F9AA337008B17CD /* Common */,
 				DC42CF2C1F926E1700279110 /* Extensions */,
 				DC42CF2A1F926D4F00279110 /* Input */,
-				DC42CF291F926D4700279110 /* Xcode */,
+				DC3062941FA9EF9A002332F6 /* Notifications */,
 				DC42CF251F922F7700279110 /* Output */,
+				DC42CF291F926D4700279110 /* Xcode */,
 				DC0E13981F5CE25E00525E5B /* main.swift */,
 				DCF555301F6610DB001567A5 /* ChuteCommandLineParameters.swift */,
 			);
@@ -174,6 +179,15 @@
 				DC4ADE3E1F9B6067007C36C1 /* ChuteCommandLineParametersTests.swift */,
 			);
 			path = chuteTests;
+			sourceTree = "<group>";
+		};
+		DC3062941FA9EF9A002332F6 /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				DC3062951FA9EFD6002332F6 /* GithubNotifier.swift */,
+				DC8BA6421FAA04BF00031B89 /* GithubDetailDifferenceComment.swift */,
+			);
+			path = Notifications;
 			sourceTree = "<group>";
 		};
 		DC42CF251F922F7700279110 /* Output */ = {
@@ -408,6 +422,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DC3062961FA9EFD6002332F6 /* GithubNotifier.swift in Sources */,
 				DC0E13A61F5DEA3500525E5B /* ChuteDetail.swift in Sources */,
 				DC0E13A21F5CE89300525E5B /* InfoPlist.swift in Sources */,
 				DC0E13991F5CE25E00525E5B /* main.swift in Sources */,
@@ -436,6 +451,7 @@
 				DCDC1B3A1F9D06FF0068170F /* ChuteOutputFolder.swift in Sources */,
 				DC0E13A01F5CE59500525E5B /* DerivedData.swift in Sources */,
 				DC4ADE1C1F9AC697007C36C1 /* ChuteHTMLOutputTemplate.swift in Sources */,
+				DC8BA6431FAA04BF00031B89 /* GithubDetailDifferenceComment.swift in Sources */,
 				DC4ADE1E1F9AC792007C36C1 /* ChuteHTMLMainReport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/chute/ChuteCommandLineParameters.swift
+++ b/chute/ChuteCommandLineParameters.swift
@@ -11,9 +11,13 @@
 //  chute
 //      -project                The Xcode project to use when creating the Chute report
 //      -branch                 The branch that resprents the captured test results
-//      -pullRequestNumber      The pull request number (optional)
 //      -compareFolder          The folder to compare the results with
 //      -saveFolder             The folder to save the test input data into
+
+//      To post a summary and optional link to full report in a github pull request, the following are needed:
+//      -githubRepository       The repository to use when posting a comment to github (format of <owner>/<repo>)
+//      -githubToken            The token to use for posting a comment to github
+//      -pullRequestNumber      The pull request number (optional)
 
 import Foundation
 
@@ -21,12 +25,19 @@ struct ChuteCommandLineParameters {
 
     let project: String?
     let branch: String?
-    let pullRequestNumber: String?
     let compareFolder: String?
     let saveFolder: String?
 
+    let githubRepository: String?
+    let githubToken: String?
+    let pullRequestNumber: String?
+
     var hasRequiredParameters: Bool {
         return project != nil
+    }
+
+    var hasParametersForGithubNotification: Bool {
+        return githubRepository != nil && githubToken != nil && pullRequestNumber != nil
     }
 
     init(arguments: [String] = CommandLine.arguments) {
@@ -42,12 +53,22 @@ struct ChuteCommandLineParameters {
 
         project = foundArguments["project"]
         branch = foundArguments["branch"]
-        pullRequestNumber = foundArguments["pullRequestNumber"]
         compareFolder = foundArguments["compareFolder"]
         saveFolder = foundArguments["saveFolder"]
+
+        githubRepository = foundArguments["githubRepository"]
+        githubToken = foundArguments["githubToken"]
+        pullRequestNumber = foundArguments["pullRequestNumber"]
     }
 
     func printInstructions() {
-        print("Usage: chute -project <project> [-branch <branch>] [-pullRequestNumber <pullRequestNumber> [-compareFolder <compareFolder>] [-saveFolder <saveFolder>]")
+        var instructions = "Usage: chute -project <project>"
+        instructions += " [-branch <branch>]"
+        instructions += " [-compareFolder <compareFolder>]"
+        instructions += " [-saveFolder <saveFolder>]"
+        instructions += " [-githubRepository <githubRepository>]"
+        instructions += " [-githubToken <githubToken>]"
+        instructions += " [-pullRequestNumber <pullRequestNumber>]"
+        print(instructions)
     }
 }

--- a/chute/Notifications/GithubDetailDifferenceComment.swift
+++ b/chute/Notifications/GithubDetailDifferenceComment.swift
@@ -1,0 +1,68 @@
+//
+//  GithubDetailDifferenceComment.swift
+//  chute
+//
+//  Created by David House on 11/1/17.
+//  Copyright © 2017 David House. All rights reserved.
+//
+
+import Foundation
+
+class GithubDetailDifferenceComment {
+
+    enum Constants {
+        static let CommentTemplate = """
+        # Chute Difference
+
+        *Test Summary*
+        - New Tests: {{new_tests}}
+        - Changed Tests: {{changed_tests}}
+        - Removed Tests: {{removed_tests}}
+
+        *Code Coverage Summary*
+        - Average Coverage: {{average_coverage}}% ({{average_coverage_change}}%)
+        - Total Files Above 90%: {{total_above_90}} {{total_above_90_change}}
+        - Total Files With No Coverage: {{total_no_coverage}} {{total_no_coverage_change}}
+
+        *Style Sheet Summary*
+        - New Colors: {{new_colors}}
+        - Removed Colors: {{removed_colors}}
+        - New Fonts: {{new_fonts}}
+        - Removed Fonts: {{removed_fonts}}
+        """
+    }
+
+    var difference: ChuteDetailDifference
+
+    lazy var comment: String = {
+        self.generateComment()
+    }()
+
+    init(difference: ChuteDetailDifference) {
+        self.difference = difference
+    }
+
+    private func generateComment() -> String {
+
+        let average_coverage_change = difference.comparedTo.codeCoverageSummary.averageCoverage - difference.detail.codeCoverageSummary.averageCoverage
+        let total_above_90_change = difference.comparedTo.codeCoverageSummary.filesAdequatelyCovered - difference.detail.codeCoverageSummary.filesAdequatelyCovered
+        let total_no_coverage_change = difference.comparedTo.codeCoverageSummary.filesWithNoCoverage - difference.detail.codeCoverageSummary.filesWithNoCoverage
+
+        let parameters: [String: CustomStringConvertible] = [
+            "new_tests": difference.testResultDifference.newTestResults.count,
+            "changed_tests": difference.testResultDifference.changedTestResults.count,
+            "removed_tests": difference.testResultDifference.removedTestResults.count,
+            "average_coverage": Int(round(difference.comparedTo.codeCoverageSummary.averageCoverage * 100)),
+            "average_coverage_change": Int(round(average_coverage_change * 100)),
+            "total_above_90": difference.codeCoverageDifference.comparedToSummary.filesAdequatelyCovered,
+            "total_above_90_change": total_above_90_change > 0 ? total_above_90_change : "",
+            "total_no_coverage": difference.codeCoverageDifference.comparedToSummary.filesWithNoCoverage,
+            "total_no_coverage_change": total_no_coverage_change > 0 ? total_no_coverage_change : "",
+            "new_colors": difference.styleSheetDifference.newColors.count,
+            "removed_colors": difference.styleSheetDifference.removedColors.count,
+            "new_fonts": difference.styleSheetDifference.newFonts.count,
+            "removed_fonts": difference.styleSheetDifference.removedFonts.count
+        ]
+        return Constants.CommentTemplate.render(parameters: parameters)
+    }
+}

--- a/chute/Notifications/GithubNotifier.swift
+++ b/chute/Notifications/GithubNotifier.swift
@@ -1,0 +1,63 @@
+//
+//  GithubNotifier.swift
+//  chute
+//
+//  Created by David House on 11/1/17.
+//  Copyright © 2017 David House. All rights reserved.
+//
+
+import Foundation
+
+class GithubNotifier {
+
+    func notify(detail: ChuteDetail, using arguments: ChuteCommandLineParameters) {
+        send(comment: "# Chute Details", to: arguments.githubRepository!, for: arguments.pullRequestNumber!, using: arguments.githubToken!)
+    }
+
+    func notify(difference: ChuteDetailDifference, using arguments: ChuteCommandLineParameters) {
+        let comment = GithubDetailDifferenceComment(difference: difference)
+        send(comment: comment.comment, to: arguments.githubRepository!, for: arguments.pullRequestNumber!, using: arguments.githubToken!)
+    }
+
+    private func send(comment: String, to repository: String, for pullRequest: String, using token: String) {
+
+        // Create a URL for this request
+        let urlString = "https://api.github.com/repos/\(repository)/issues/\(pullRequest)/comments"
+        guard let postURL = URL(string: urlString) else {
+            print("--- Error creating URL for posting to github: \(urlString)")
+            return
+        }
+
+        var request = URLRequest(url: postURL)
+        request.httpMethod = "POST"
+        request.setValue("token \(token)", forHTTPHeaderField: "Authorization")
+
+        let body: [String: String] = [
+            "body": comment
+        ]
+        let encoder = JSONEncoder()
+        do {
+            let rawBody = try encoder.encode(body)
+            request.httpBody = rawBody
+        } catch {
+            print("--- Error encoding body: \(error)")
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        let dataTask = URLSession(configuration: URLSessionConfiguration.default).dataTask(with: request) { (data, _, error) in
+
+            print("data task completed!")
+            if let error = error {
+                print("--- Error posting comment to github: \(error.localizedDescription)")
+            }
+
+            if let data = data {
+                let dataString = String(data: data, encoding: .utf8)
+                print("--- Response: \(dataString ?? "")")
+            }
+            semaphore.signal()
+        }
+        dataTask.resume()
+        _ = semaphore.wait(timeout: DispatchTime.now() + DispatchTimeInterval.seconds(30))
+    }
+}

--- a/chute/main.swift
+++ b/chute/main.swift
@@ -123,6 +123,25 @@ if let compareFolder = arguments.compareFolder {
 
     let compareDetails = ChuteDetailDifference(detail: beforeTestDetail, comparedTo: chuteTestDetail, detailAttachmentURL: beforeAttachmentsURL, comparedToAttachmentURL: rootAttachmentPath)
     output.renderHTMLDifferenceOutput(difference: compareDetails)
+
+    print("---")
+    print("--- Generating notifications")
+    print("---")
+
+    if arguments.hasParametersForGithubNotification {
+        let notifier = GithubNotifier()
+        notifier.notify(difference: compareDetails, using: arguments)
+    }
+} else {
+
+    print("---")
+    print("--- Generating notifications")
+    print("---")
+
+    if arguments.hasParametersForGithubNotification {
+        let notifier = GithubNotifier()
+        notifier.notify(detail: chuteTestDetail, using: arguments)
+    }
 }
 
 // If save set, save the gathered data


### PR DESCRIPTION
This PR adds a mechanism to post a summary of the chute difference report to a GitHub PR. Still work to be done to embed images (thumbnails?) so a PR reviewer can easily see what screens are changed in the PR. Also a way to see further details about the differences.