### PR TITLE
Add some parameters to support GitHub enterprise builds

### DIFF
--- a/chute/Common/CommandLine.swift
+++ b/chute/Common/CommandLine.swift
@@ -21,7 +21,10 @@
 //      -githubPagesFolder      The root folder in Github Pages branch for publishing to
 //
 //      -publishRootURL         The root http url where the published files will be found
+//      -githubHost             The host name if using github enterprise
+//      -githubAPIURL           The API URL if using github enterprise
 
+//      -derivedDataFolder            Root folder for DerivedData
 import Foundation
 
 struct CommandLineArguments {
@@ -34,10 +37,14 @@ struct CommandLineArguments {
     let githubToken: String?
     let pullRequestNumber: String?
     let githubPagesFolder: String?
-
+    let githubHost: String?
+    let githubAPIURL: String?
+    
     let slackWebhook: String?
 
     let publishRootURL: String?
+    
+    let derivedDataFolder: String?
     
     var hasRequiredParameters: Bool {
         return project != nil
@@ -78,6 +85,11 @@ struct CommandLineArguments {
         slackWebhook = foundArguments["slackWebhook"] != nil ? foundArguments["slackWebhook"] : ProcessInfo.processInfo.environment["CHUTE_SLACK_WEBHOOK"]
         
         publishRootURL = foundArguments["publishRootURL"] != nil ? foundArguments["publishRootURL"] : ProcessInfo.processInfo.environment["CHUTE_PUBLISH_ROOT_URL"]
+        
+        githubHost = foundArguments["githubHost"] != nil ? foundArguments["githubHost"] : ProcessInfo.processInfo.environment["CHUTE_GITHUB_HOST"]
+        githubAPIURL = foundArguments["githubAPIURL"] != nil ? foundArguments["githubAPIURL"] : ProcessInfo.processInfo.environment["CHUTE_GITHUB_APIURL"]
+        
+        derivedDataFolder = foundArguments["derivedDataFolder"] != nil ? foundArguments["derivedDataFolder"] : ProcessInfo.processInfo.environment["CHUTE_DERIVED_DATA_FOLDER"];
     }
 
     func printInstructions() {
@@ -90,6 +102,9 @@ struct CommandLineArguments {
         instructions += " [-githubPagesFolder <githubPagesFolder>]"
         instructions += " [-slackWebhook <slackWebhook>]"
         instructions += " [-publishRootURL <publishRootURL>]"
+        instructions += " [-githubHost <githubHost>]"
+        instructions += " [-githubAPIURL <githubAPIURL>]"
+        instructions += " [-derivedDataFolder <derivedDataFolder>]"
         print(instructions)
     }
 }
@@ -106,5 +121,8 @@ extension CommandLineArguments: Printable {
         print("Github Pages Folder: \(githubPagesFolder ?? "")")
         print("Slack Webhook: \(slackWebhook ?? "")")
         print("Publish Root URL: \(publishRootURL ?? "")")
+        print("Github Host: \(githubHost ?? "")")
+        print("Github API URL: \(githubAPIURL ?? "")")
+        print("Derived Data Folder: \(derivedDataFolder ?? "")")
     }
 }

--- a/chute/Common/Environment.swift
+++ b/chute/Common/Environment.swift
@@ -38,7 +38,7 @@ class Environment {
         let projectFileURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent(project)
         self.projectFileURL = projectFileURL
 
-        self.derivedData = DerivedData(projectFileURL: projectFileURL)
+        self.derivedData = DerivedData(projectFileURL: projectFileURL, derivedDataFolder: arguments.derivedDataFolder)
     }
 }
 

--- a/chute/Notifications/GithubNotifier.swift
+++ b/chute/Notifications/GithubNotifier.swift
@@ -15,7 +15,7 @@ class GithubNotifier {
         if let repository = environment.arguments.githubRepository, let pullRequestNumber = environment.arguments.pullRequestNumber, let token = environment.arguments.githubToken {
             
             let comment = GithubDetailComment(dataCapture: dataCapture, publishedURL: publishedURL)
-            send(comment: comment.comment, to: repository, for: pullRequestNumber, using: token)
+            send(comment: comment.comment, to: repository, for: pullRequestNumber, using: token, apiurl: environment.arguments.githubAPIURL)
         }
     }
 
@@ -24,14 +24,14 @@ class GithubNotifier {
         if let repository = environment.arguments.githubRepository, let pullRequestNumber = environment.arguments.pullRequestNumber, let token = environment.arguments.githubToken {
             
             let comment = GithubDetailDifferenceComment(difference: difference, publishedURL: publishedURL)
-            send(comment: comment.comment, to: repository, for: pullRequestNumber, using: token)
+            send(comment: comment.comment, to: repository, for: pullRequestNumber, using: token, apiurl: environment.arguments.githubAPIURL)
         }
     }
 
-    private func send(comment: String, to repository: String, for pullRequest: String, using token: String) {
+    private func send(comment: String, to repository: String, for pullRequest: String, using token: String, apiurl: String?) {
 
         // Create a URL for this request
-        let urlString = "https://api.github.com/repos/\(repository)/issues/\(pullRequest)/comments"
+        let urlString = "https://\(apiurl ?? "api.github.com")/repos/\(repository)/issues/\(pullRequest)/comments"
         guard let postURL = URL(string: urlString) else {
             print("--- Error creating URL for posting to github: \(urlString)")
             return

--- a/chute/Publishing/GithubPagesPublisher.swift
+++ b/chute/Publishing/GithubPagesPublisher.swift
@@ -57,7 +57,7 @@ class GithubPagesPublisher {
         print("Publish root folder: \(publishRootURL)")
         
         // Do a git clone from the repo using gh-pages branch into /tmp/chute
-        let output = Execute.shell(command: ["-l", "-c", "cd \(publishRootURL.path) && git clone -b gh-pages git@github.com:\(repository).git gh-pages"])
+        let output = Execute.shell(command: ["-l", "-c", "cd \(publishRootURL.path) && git clone -b gh-pages git@\(environment.arguments.githubHost ?? "github.com"):\(repository).git gh-pages"])
         print(output ?? "")
         
         // Copy the reports & attachments

--- a/chute/Xcode/InfoPlist.swift
+++ b/chute/Xcode/InfoPlist.swift
@@ -21,7 +21,8 @@ struct InfoPlist: Codable {
 extension InfoPlist {
 
     static func from(file: URL) -> InfoPlist? {
-        if let data = try? Data(contentsOf: file) {
+        do {
+            let data = try Data(contentsOf: file)
             let decoder = PropertyListDecoder()
             do {
                 let plist = try decoder.decode(InfoPlist.self, from: data)
@@ -29,6 +30,8 @@ extension InfoPlist {
             } catch {
                 print(error)
             }
+        } catch {
+            print("Error reading plist file: \(error)")
         }
         return nil
     }


### PR DESCRIPTION
Adds new parameters to support Github enterprise, including the gh host and api endpoint. Also adds a derivedDataFolder parameter for use on CI systems where the derived data folder for `xcodebuild` is overridden.