### PR TITLE
Limit gh-pages output to pr or branch folders

### DIFF
--- a/chute/Notifications/Notifier.swift
+++ b/chute/Notifications/Notifier.swift
@@ -19,9 +19,17 @@ class Notifier {
             return nil
         }
         
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMddHHmmss"
-        let folderName = formatter.string(from: self.dataCapture.testExecutionDate)
+        let folderName: String = {
+        
+            if let pullRequestNumber = arguments.pullRequestNumber {
+                return pullRequestNumber
+            } else if let branch = arguments.branch {
+                return branch
+            } else {
+                return "chute"
+            }
+        }()
+
         let captureURL = rootURL.appendingPathComponents([folderName, "chute.html"])
         return captureURL.description
     }()
@@ -31,9 +39,17 @@ class Notifier {
             return nil
         }
         
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMddHHmmss"
-        let folderName = formatter.string(from: self.dataCapture.testExecutionDate)
+        let folderName: String = {
+            
+            if let pullRequestNumber = arguments.pullRequestNumber {
+                return pullRequestNumber
+            } else if let branch = arguments.branch {
+                return branch
+            } else {
+                return "chute"
+            }
+        }()
+        
         let captureURL = rootURL.appendingPathComponents([folderName, "chute_difference.html"])
         return captureURL.description
     }()


### PR DESCRIPTION
This PR causes the gh-pages output to save either to a folder for each PR, or a folder for the branch specified. This greatly helps with the size of the gh-pages repo, but some history will be lost for branches since it only keeps the latest results.

Fixes #25 